### PR TITLE
Retirado o volume do mongodb para funcionar no Windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       driver: none
     ports:
       - "27017:27017"
-    volumes:
-      - ./data/db:/data/db
 
   server:
     build: './server/' 


### PR DESCRIPTION
Alterado o aquivo docker-compose.yml.
Retirado o volume do mongodb para funcionar no Windows